### PR TITLE
Fix naming in SFNT

### DIFF
--- a/rename-font
+++ b/rename-font
@@ -12,14 +12,14 @@ parser.add_argument("--name", help="font name")
 args = parser.parse_args()
 
 # Open the file
-delugia=fontforge.open(args.input)              
+delugia=fontforge.open(args.input)
 
 # Rename the file
 delugia.fontname="{}-Regular".format(args.name)
 delugia.familyname=args.name
 delugia.fullname=args.name
 delugia.appendSFNTName("English (US)", "Copyright", "Need something here")
-delugia.appendSFNTName("English (US)", "UniqueID", "{} Regular".format(name))
+delugia.appendSFNTName("English (US)", "UniqueID", "{} Regular".format(args.name))
 delugia.appendSFNTName("English (US)", "Trademark", "")
 
 # Save

--- a/rename-font
+++ b/rename-font
@@ -15,10 +15,12 @@ args = parser.parse_args()
 delugia=fontforge.open(args.input)              
 
 # Rename the file
-delugia.fontname=args.name
+delugia.fontname="{}-Regular".format(args.name)
 delugia.familyname=args.name
 delugia.fullname=args.name
-delugia.copyright=args.name
+delugia.appendSFNTName("English (US)", "Copyright", "Need something here")
+delugia.appendSFNTName("English (US)", "UniqueID", "{} Regular".format(name))
+delugia.appendSFNTName("English (US)", "Trademark", "")
 
 # Save
 delugia.generate(args.output)

--- a/rename-font
+++ b/rename-font
@@ -15,7 +15,7 @@ args = parser.parse_args()
 delugia=fontforge.open(args.input)
 
 # Rename the file
-delugia.fontname="{}-Regular".format(args.name)
+delugia.fontname="{}-Regular".format(args.name).replace(" ", "")
 delugia.familyname=args.name
 delugia.fullname=args.name
 delugia.appendSFNTName("English (US)", "Copyright", "Need something here")


### PR DESCRIPTION
[why]
The PS name and the UniqueID should match.

[how]
Invent usual the 'Regular' name. Hyphenated for PS, with blanc for SFNT.

Copyright needs some value. I'm not sure if it should be removed.
Same goes with the Trademark field. But here we just erase it.

[note]
This might fix Issue #7, can't check because I lack Windows.

Signed-off-by: Fini Jastrow <ulf.fini.jastrow@desy.de>