### PR TITLE
Correct additional SFNT names

### DIFF
--- a/rename-font
+++ b/rename-font
@@ -18,6 +18,8 @@ delugia=fontforge.open(args.input)
 delugia.fontname="{}-Regular".format(args.name).replace(" ", "")
 delugia.familyname=args.name
 delugia.fullname=args.name
+delugia.appendSFNTName("English (US)", "Preferred Family", args.name)
+delugia.appendSFNTName("English (US)", "Compatible Full", args.name)
 delugia.appendSFNTName("English (US)", "Copyright", "Need something here")
 delugia.appendSFNTName("English (US)", "UniqueID", "{} Regular".format(args.name))
 delugia.appendSFNTName("English (US)", "Trademark", "")


### PR DESCRIPTION
[why]
The Windows font manager seems to use these to categorize the fonts.

[how]
Tested on Windows 10 1809

Fixes: 7
Signed-off-by: Fini Jastrow <ulf.fini.jastrow@desy.de>