### PR TITLE
Do not forcefully convert font to be singlespaced

### DIFF
--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -25,12 +25,12 @@ jobs:
       run: pip install configparser
     - name: Build Powerline
       run: |
-        fontforge -script font-patcher --powerline --no-progressbars --mono Cascadia.ttf     
-        fontforge rename-font --input "Cascadia Code Nerd Font Mono.ttf" --output "Delugia Nerd Font.ttf" --name "Delugia Nerd Font"
+        fontforge -script font-patcher --powerline --no-progressbars Cascadia.ttf
+        fontforge rename-font --input "Cascadia Code Nerd Font.ttf" --output "Delugia Nerd Font.ttf" --name "Delugia Nerd Font"
     - name: Build Complete
       run: |
-        fontforge -script font-patcher -c --no-progressbars --mono Cascadia.ttf 
-        fontforge rename-font --input "Cascadia Code Nerd Font Complete Mono.ttf" --output "Delugia Nerd Font Complete.ttf" --name "Delugia Nerd Font"
+        fontforge -script font-patcher -c --no-progressbars Cascadia.ttf
+        fontforge rename-font --input "Cascadia Code Nerd Font Complete.ttf" --output "Delugia Nerd Font Complete.ttf" --name "Delugia Nerd Font"
     - uses: actions/upload-artifact@master
       with:
         name: Delugia Nerd Font Powerline


### PR DESCRIPTION
[why]
The font has ligatures, so some glyphs need the space for two single
glyphs. Forcing the glyph width to 'single' breaks display of the
ligatures in editors that support them (e.g. Visual Studio).

Note the difference in the ligatures of ``==`` and ``++``.

With --mono:

![Selection_239](https://user-images.githubusercontent.com/16012374/67284991-f90bf580-f4d6-11e9-9b82-d2d7bb0bfb63.png)

[how]
Remove --mono option.

![Selection_240](https://user-images.githubusercontent.com/16012374/67285066-28bafd80-f4d7-11e9-8bc8-09b30fc7d364.png)


Having the glyphs double width dones not influence monospaced usage.

![Selection_242](https://user-images.githubusercontent.com/16012374/67285270-8ea78500-f4d7-11e9-8183-d47c8d72213f.png)

[note]
Tested with Visual Studio 19 Community 16.3.2
Tested with Gnome Terminal / Powerline

[note]
There was a request for ``--mono`` by @onovotny in Issue #3 (PR #6).
I have no solution for this. Ligature support obviously breaks with ``--mono`` and that the font is not marked _monospaced_ can be counted as minor glitch. Shrug. At least better than the broken ligatures.

Signed-off-by: Fini Jastrow <ulf.fini.jastrow@desy.de>