### PR TITLE
Fix width of glyph 'grave'

### DIFF
--- a/rename-font
+++ b/rename-font
@@ -24,5 +24,9 @@ delugia.appendSFNTName("English (US)", "Copyright", "Need something here")
 delugia.appendSFNTName("English (US)", "UniqueID", "{} Regular".format(args.name))
 delugia.appendSFNTName("English (US)", "Trademark", "")
 
+# The grave accent type is somehow not correctly detected;
+# we want it to be an ordinary character
+delugia["grave"].glyphclass="baseglyph"
+
 # Save
 delugia.generate(args.output)


### PR DESCRIPTION
[why]
On Applications that can work with ligatures and non-monospaced fonts
the grave accent is handled as if it has zero width. The next character
is drawn directly on top of the accent, resulting in an accented letter
(where there is none) or only one accent if there are many consecutive
ones.

[how]
It is not clear why the character fails to have any width, but if the
glyph type is set to handle this glyph as ordinary character the
handling is ok. Somehow the autodetection of glyph type is broken?

Fixes: #5 
Signed-off-by: Fini Jastrow <ulf.fini.jastrow@desy.de>