### PR TITLE
Leave copyright field in the font intact

### DIFF
--- a/rename-font
+++ b/rename-font
@@ -20,7 +20,6 @@ delugia.familyname=args.name
 delugia.fullname=args.name
 delugia.appendSFNTName("English (US)", "Preferred Family", args.name)
 delugia.appendSFNTName("English (US)", "Compatible Full", args.name)
-delugia.appendSFNTName("English (US)", "Copyright", "Need something here")
 delugia.appendSFNTName("English (US)", "UniqueID", "{} Regular".format(args.name))
 delugia.appendSFNTName("English (US)", "Trademark", "")
 


### PR DESCRIPTION
[why]
Microsoft's license is as follows (excerpt):

>   Permission is hereby granted [to] modify [...] the Font Software, subject to
>   the following conditions:
> 
>   2) Original or Modified Versions of the Font Software may be bundled,
>   redistributed [...], provided that each copy contains the above copyright
>   notice and this license.
> 

[how]
Stop overwriting the existing copyright notice with nonsense.