### PR TITLE
Add identifier of patch mechanism to font version

### DIFF
--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build Complete
       run: |
         fontforge -script font-patcher -c --no-progressbars --mono Cascadia.ttf 
-        fontforge rename-font --input "Cascadia Code Nerd Font Complete Mono.ttf" --output "Delugia Nerd Font Complete.ttf" --name "Delugia Nerd Font"
+        git describe --always | xargs fontforge rename-font --input "Cascadia Code Nerd Font Complete Mono.ttf" --output "Delugia Nerd Font Complete.ttf" --name "Delugia Nerd Font" --version
     - uses: actions/upload-artifact@master
       with:
         name: Delugia Nerd Font Powerline

--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Build Powerline
       run: |
         fontforge -script font-patcher --powerline --no-progressbars --mono Cascadia.ttf     
-        fontforge rename-font --input "Cascadia Code Nerd Font Mono.ttf" --output "Delugia Nerd Font.ttf" --name "Delugia Nerd Font"
+        git describe --always | xargs fontforge rename-font --input "Cascadia Code Nerd Font Mono.ttf" --output "Delugia Nerd Font.ttf" --name "Delugia Nerd Font" --hash
     - name: Build Complete
       run: |
         fontforge -script font-patcher -c --no-progressbars --mono Cascadia.ttf 

--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -4,17 +4,17 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Download latest version of Cascadia 
+    - name: Download latest version of Cascadia
       run: curl -L https://github.com/microsoft/cascadia-code/releases/latest/download/Cascadia.ttf  --output Cascadia.ttf
     - name: Install FontForge
       run: |
         sudo add-apt-repository ppa:fontforge/fontforge -y -u;
         sudo apt-get install fontforge -y;
     - name: Download Font Patcher
-      run: curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/master/font-patcher --output font-patcher 
+      run: curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/master/font-patcher --output font-patcher
     - name: Patch Font Patcher for Ligature Glyphs
       run: patch -u font-patcher < font-patcher.patch
     - name: Download source fonts
@@ -27,16 +27,22 @@ jobs:
       run: pip install configparser
     - name: Build Powerline
       run: |
-        fontforge -script font-patcher --powerline --no-progressbars --mono Cascadia.ttf     
-        git describe --always | xargs fontforge rename-font --input "Cascadia Code Nerd Font Mono.ttf" --output "Delugia Nerd Font.ttf" --name "Delugia Nerd Font" --version
+        fontforge -script font-patcher --powerline --no-progressbars --mono Cascadia.ttf
+        git describe --always | xargs fontforge rename-font --input "Cascadia Code Nerd Font Mono.ttf" \
+                                                            --output "Delugia Nerd Font.ttf" \
+                                                            --name "Delugia Nerd Font" \
+                                                            --version
     - name: Build Complete
       run: |
-        fontforge -script font-patcher -c --no-progressbars --mono Cascadia.ttf 
-        git describe --always | xargs fontforge rename-font --input "Cascadia Code Nerd Font Complete Mono.ttf" --output "Delugia Nerd Font Complete.ttf" --name "Delugia Nerd Font" --version
+        fontforge -script font-patcher -c --no-progressbars --mono Cascadia.ttf
+        git describe --always | xargs fontforge rename-font --input "Cascadia Code Nerd Font Complete Mono.ttf" \
+                                                            --output "Delugia Nerd Font Complete.ttf" \
+                                                            --name "Delugia Nerd Font" \
+                                                            --version
     - uses: actions/upload-artifact@master
       with:
         name: Delugia Nerd Font Powerline
-        path: "Delugia Nerd Font.ttf"        
+        path: "Delugia Nerd Font.ttf"
     - uses: actions/upload-artifact@master
       with:
         name: Delugia Nerd Font Complete

--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Build Powerline
       run: |
         fontforge -script font-patcher --powerline --no-progressbars --mono Cascadia.ttf     
-        git describe --always | xargs fontforge rename-font --input "Cascadia Code Nerd Font Mono.ttf" --output "Delugia Nerd Font.ttf" --name "Delugia Nerd Font" --hash
+        git describe --always | xargs fontforge rename-font --input "Cascadia Code Nerd Font Mono.ttf" --output "Delugia Nerd Font.ttf" --name "Delugia Nerd Font" --version
     - name: Build Complete
       run: |
         fontforge -script font-patcher -c --no-progressbars --mono Cascadia.ttf 

--- a/rename-font
+++ b/rename-font
@@ -9,6 +9,7 @@ parser = ArgumentParser()
 parser.add_argument("--input", help="input file name")
 parser.add_argument("--output", help="output file name")
 parser.add_argument("--name", help="font name")
+parser.add_argument("--version", help="(optional) text to add to the existing version")
 args = parser.parse_args()
 
 # Open the file
@@ -27,6 +28,10 @@ delugia.appendSFNTName("English (US)", "Trademark", "")
 # The grave accent type is somehow not correctly detected;
 # we want it to be an ordinary character
 delugia["grave"].glyphclass="baseglyph"
+
+# Mix our version information in
+if (args.version):
+    delugia.version="{}/{}".format(delugia.version, args.version)
 
 # Save
 delugia.generate(args.output)


### PR DESCRIPTION
[why]
Sometimes it is useful to know which version of the font patching system
actually patched the created files - apart from the modification date.

[how]
Add the git description to Microsofts font version. If we would use
release tags, these would show up there. At the moment only the
abbrevated git hash is shown.

The deliminator is '/' rather than '.' because the later would suggest
semantic versioning. But this is rather two unrelated version numbers
stuffed together in one field.

[note]
I hope the necessary tools are available on the github host.
We will see in a minute if the build-on-pull-request succeeds.

Fixes #13 ... somehow. We would need to set git tags (`git tag -m`) to get
meaningful version numbers from our side.

Gosh, forgot... uses `git describe --always` as additional version identifier.