### PR TITLE
Put new version number also in SFNT

### DIFF
--- a/rename-font
+++ b/rename-font
@@ -30,7 +30,10 @@ delugia["grave"].glyphclass="baseglyph"
 
 # Mix our version information in
 if (args.version):
-    delugia.version="{}/{}".format(delugia.version, args.version)
+    enriched_version = "{}/{}".format(delugia.version, args.version)
+    delugia.appendSFNTName("English (US)", "Version", enriched_version)
+    delugia.version = enriched_version
+    print("Set new font version {}".format(delugia.version));
 
 # Save
 delugia.generate(args.output)


### PR DESCRIPTION
[why]
With commit #7de970a Add identifier of patch mechanism to font version (#15)
the font version number has been appended by our git version.

But this is not visible.

[how]
We need to update the SFNT table entry also.

Here a screenshot under Windows with version number:
![Selection_251](https://user-images.githubusercontent.com/16012374/67575337-a59ae100-f73c-11e9-9e43-5e91c00aed3a.png)
