### PR TITLE
Adapt to new Cascadia Code weight

### DIFF
--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -27,18 +27,21 @@ jobs:
       run: pip install configparser
     - name: Build Powerline
       run: |
-        fontforge -script font-patcher --powerline --no-progressbars --mono Cascadia.ttf
+        fontforge -script font-patcher --careful --powerline --no-progressbars --mono Cascadia.ttf | tee process.log
         git describe --always | xargs fontforge rename-font --input Cascadia*\ Nerd\ Font\ Mono.ttf \
                                                             --output "Delugia Nerd Font.ttf" \
                                                             --name "Delugia Nerd Font" \
                                                             --version
     - name: Build Complete
       run: |
-        fontforge -script font-patcher -c --no-progressbars --mono Cascadia.ttf
+        fontforge -script font-patcher --careful -c --no-progressbars --mono Cascadia.ttf | tee process_full.log
         git describe --always | xargs fontforge rename-font --input Cascadia*\ Nerd\ Font\ Complete\ Mono.ttf \
                                                             --output "Delugia Nerd Font Complete.ttf" \
                                                             --name "Delugia Nerd Font" \
                                                             --version
+    - name: Check for preexisting glyphs
+      run: |
+        grep 'Found existing' process*.log
     - uses: actions/upload-artifact@master
       with:
         name: Delugia Nerd Font Powerline

--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -28,14 +28,14 @@ jobs:
     - name: Build Powerline
       run: |
         fontforge -script font-patcher --powerline --no-progressbars --mono Cascadia.ttf
-        git describe --always | xargs fontforge rename-font --input "Cascadia Code Nerd Font Mono.ttf" \
+        git describe --always | xargs fontforge rename-font --input Cascadia*\ Nerd\ Font\ Mono.ttf \
                                                             --output "Delugia Nerd Font.ttf" \
                                                             --name "Delugia Nerd Font" \
                                                             --version
     - name: Build Complete
       run: |
         fontforge -script font-patcher -c --no-progressbars --mono Cascadia.ttf
-        git describe --always | xargs fontforge rename-font --input "Cascadia Code Nerd Font Complete Mono.ttf" \
+        git describe --always | xargs fontforge rename-font --input Cascadia*\ Nerd\ Font\ Complete\ Mono.ttf \
                                                             --output "Delugia Nerd Font Complete.ttf" \
                                                             --name "Delugia Nerd Font" \
                                                             --version


### PR DESCRIPTION
Microsoft added the 'regular' weight to Cascadia Code with their latest release.
This breaks our workflow, because the font-patcher brings the internal names out as filename.

This commit makes our workflow immune to some/most font naming changes.

It also adds a step in the workflow that highlights glyph clashes.