### PR TITLE
fixup: Use specific Nerd Font release

### DIFF
--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -14,7 +14,7 @@ jobs:
         sudo add-apt-repository ppa:fontforge/fontforge -y -u;
         sudo apt-get install fontforge -y;
     - name: Download Font Patcher
-      run: curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/master/font-patcher --output font-patcher
+      run: curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v2.1.0/font-patcher --output font-patcher
     - name: Download source fonts
       run: |
         chmod +x download-source-fonts.sh
@@ -26,14 +26,14 @@ jobs:
     - name: Build Powerline
       run: |
         fontforge -script font-patcher --careful --powerline --no-progressbars --mono Cascadia.ttf | tee process.log
-        git describe --always | xargs fontforge rename-font --input Cascadia*\ Nerd\ Font\ Mono.ttf \
+        git describe --always | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Mono.ttf \
                                                             --output "Delugia Nerd Font.ttf" \
                                                             --name "Delugia Nerd Font" \
                                                             --version
     - name: Build Complete
       run: |
         fontforge -script font-patcher --careful -c --no-progressbars --mono Cascadia.ttf | tee process_full.log
-        git describe --always | xargs fontforge rename-font --input Cascadia*\ Nerd\ Font\ Complete\ Mono.ttf \
+        git describe --always | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Complete\ Mono.ttf \
                                                             --output "Delugia Nerd Font Complete.ttf" \
                                                             --name "Delugia Nerd Font" \
                                                             --version

--- a/download-source-fonts.sh
+++ b/download-source-fonts.sh
@@ -2,21 +2,21 @@
 
 mkdir -p src/glyphs
 
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/FontAwesome.otf?raw=true --output src/glyphs/FontAwesome.otf
-curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/master/src/glyphs/NerdFontsSymbols%201000%20EM%20Nerd%20Font%20Complete%20Blank.sfd --output "src/glyphs/NerdFontsSymbols 1000 EM Nerd Font Complete Blank.sfd"
-curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/master/src/glyphs/NerdFontsSymbols%202048%20EM%20Nerd%20Font%20Complete%20Blank.sfd --output "src/glyphs/NerdFontsSymbols 2048 EM Nerd Font Complete Blank.sfd"
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/Pomicons.otf?raw=true --output src/glyphs/Pomicons.otf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/PowerlineExtraSymbols.otf?raw=true --output src/glyphs/PowerlineExtraSymbols.otf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/PowerlineSymbols.otf?raw=true --output src/glyphs/PowerlineSymbols.otf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/Symbols%20Template%201000%20em.ttf?raw=true --output "src/glyphs/Symbols Template 1000 em.ttf"
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/Symbols%20Template%202048%20em.ttf?raw=true --output "src/glyphs/Symbols Template 2048 em.ttf"
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/Symbols-1000-em%20Nerd%20Font%20Complete.ttf?raw=true --output "src/glyphs/Symbols-1000-em Nerd Font Complete.ttf"
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/Symbols-2048-em%20Nerd%20Font%20Complete.ttf?raw=true --output "src/glyphs/Symbols-2048-em Nerd Font Complete.ttf"
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/Unicode_IEC_symbol_font.otf?raw=true --output src/glyphs//Unicode_IEC_symbol_font.otf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/devicons.ttf?raw=true --output src/glyphs/devicons.ttf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/font-awesome-extension.ttf?raw=true --output src/glyphs/font-awesome-extension.ttf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/font-logos.ttf?raw=true --output src/glyphs/font-logos.ttf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/materialdesignicons-webfont.ttf?raw=true --output src/glyphs/materialdesignicons-webfont.ttf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/octicons.ttf?raw=true --output src/glyphs/octicons.ttf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/original-source.otf?raw=true --output src/glyphs/original-source.otf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/weathericons-regular-webfont.ttf?raw=true --output src/glyphs/weathericons-regular-webfont.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/FontAwesome.otf?raw=true --output src/glyphs/FontAwesome.otf
+curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v2.1.0/src/glyphs/NerdFontsSymbols%201000%20EM%20Nerd%20Font%20Complete%20Blank.sfd --output "src/glyphs/NerdFontsSymbols 1000 EM Nerd Font Complete Blank.sfd"
+curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v2.1.0/src/glyphs/NerdFontsSymbols%202048%20EM%20Nerd%20Font%20Complete%20Blank.sfd --output "src/glyphs/NerdFontsSymbols 2048 EM Nerd Font Complete Blank.sfd"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Pomicons.otf?raw=true --output src/glyphs/Pomicons.otf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/PowerlineExtraSymbols.otf?raw=true --output src/glyphs/PowerlineExtraSymbols.otf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/PowerlineSymbols.otf?raw=true --output src/glyphs/PowerlineSymbols.otf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Symbols%20Template%201000%20em.ttf?raw=true --output "src/glyphs/Symbols Template 1000 em.ttf"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Symbols%20Template%202048%20em.ttf?raw=true --output "src/glyphs/Symbols Template 2048 em.ttf"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Symbols-1000-em%20Nerd%20Font%20Complete.ttf?raw=true --output "src/glyphs/Symbols-1000-em Nerd Font Complete.ttf"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Symbols-2048-em%20Nerd%20Font%20Complete.ttf?raw=true --output "src/glyphs/Symbols-2048-em Nerd Font Complete.ttf"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Unicode_IEC_symbol_font.otf?raw=true --output src/glyphs//Unicode_IEC_symbol_font.otf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/devicons.ttf?raw=true --output src/glyphs/devicons.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/font-awesome-extension.ttf?raw=true --output src/glyphs/font-awesome-extension.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/font-logos.ttf?raw=true --output src/glyphs/font-logos.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/materialdesignicons-webfont.ttf?raw=true --output src/glyphs/materialdesignicons-webfont.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/octicons.ttf?raw=true --output src/glyphs/octicons.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/original-source.otf?raw=true --output src/glyphs/original-source.otf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/weathericons-regular-webfont.ttf?raw=true --output src/glyphs/weathericons-regular-webfont.ttf


### PR DESCRIPTION
[why]
When Nerd Font evolves and new commits become pulled to master our
scripts might break.

See also warning at
  https://github.com/ryanoasis/nerd-fonts#unstable-file-paths

This is the case here, because Nerd Fonts decided to rename Cascadia
when it patches it. Our subsequent renaming then failes.

[how]
Reference release v2.1.0 as this is master at the moment.
Adapt to new output file name.