### PR TITLE
Feature/add more math glyphs

### DIFF
--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -14,7 +14,7 @@ jobs:
         sudo add-apt-repository ppa:fontforge/fontforge -y -u;
         sudo apt-get install fontforge -y;
     - name: Download Font Patcher
-      run: curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/master/font-patcher --output font-patcher
+      run: curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v2.1.0/font-patcher --output font-patcher
     - name: Download source fonts
       run: |
         chmod +x download-source-fonts.sh
@@ -26,14 +26,14 @@ jobs:
     - name: Build Powerline
       run: |
         fontforge -script font-patcher --careful --powerline --no-progressbars --mono Cascadia.ttf | tee process.log
-        git describe --always | xargs fontforge rename-font --input Cascadia*\ Nerd\ Font\ Mono.ttf \
+        git describe --always | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Mono.ttf \
                                                             --output "Delugia Nerd Font.ttf" \
                                                             --name "Delugia Nerd Font" \
                                                             --version
     - name: Build Complete
       run: |
         fontforge -script font-patcher --careful -c --no-progressbars --mono Cascadia.ttf | tee process_full.log
-        git describe --always | xargs fontforge rename-font --input Cascadia*\ Nerd\ Font\ Complete\ Mono.ttf \
+        git describe --always | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Complete\ Mono.ttf \
                                                             --output "Delugia Nerd Font Complete.ttf" \
                                                             --name "Delugia Nerd Font" \
                                                             --version

--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -23,16 +23,20 @@ jobs:
       run: sudo apt install python-pip -y
     - name: Install configparser
       run: pip install configparser
+    - name: Extract additional powerline glyphs
+      run: fontforge -lang=ff -script extract-math-glyphs
     - name: Build Powerline
       run: |
-        fontforge -script font-patcher --careful --powerline --no-progressbars --mono Cascadia.ttf | tee process.log
+        fontforge -script font-patcher --careful --powerline --custom SomeMathSymbols.otf \
+                                       --no-progressbars --mono Cascadia.ttf | tee process.log
         git describe --always | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Mono.ttf \
                                                             --output "Delugia Nerd Font.ttf" \
                                                             --name "Delugia Nerd Font" \
                                                             --version
     - name: Build Complete
       run: |
-        fontforge -script font-patcher --careful -c --no-progressbars --mono Cascadia.ttf | tee process_full.log
+        fontforge -script font-patcher --careful -c --custom SomeMathSymbols.otf \
+                                       --no-progressbars --mono Cascadia.ttf | tee process_full.log
         git describe --always | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Complete\ Mono.ttf \
                                                             --output "Delugia Nerd Font Complete.ttf" \
                                                             --name "Delugia Nerd Font" \

--- a/download-source-fonts.sh
+++ b/download-source-fonts.sh
@@ -2,21 +2,21 @@
 
 mkdir -p src/glyphs
 
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/FontAwesome.otf?raw=true --output src/glyphs/FontAwesome.otf
-curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/master/src/glyphs/NerdFontsSymbols%201000%20EM%20Nerd%20Font%20Complete%20Blank.sfd --output "src/glyphs/NerdFontsSymbols 1000 EM Nerd Font Complete Blank.sfd"
-curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/master/src/glyphs/NerdFontsSymbols%202048%20EM%20Nerd%20Font%20Complete%20Blank.sfd --output "src/glyphs/NerdFontsSymbols 2048 EM Nerd Font Complete Blank.sfd"
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/Pomicons.otf?raw=true --output src/glyphs/Pomicons.otf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/PowerlineExtraSymbols.otf?raw=true --output src/glyphs/PowerlineExtraSymbols.otf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/PowerlineSymbols.otf?raw=true --output src/glyphs/PowerlineSymbols.otf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/Symbols%20Template%201000%20em.ttf?raw=true --output "src/glyphs/Symbols Template 1000 em.ttf"
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/Symbols%20Template%202048%20em.ttf?raw=true --output "src/glyphs/Symbols Template 2048 em.ttf"
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/Symbols-1000-em%20Nerd%20Font%20Complete.ttf?raw=true --output "src/glyphs/Symbols-1000-em Nerd Font Complete.ttf"
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/Symbols-2048-em%20Nerd%20Font%20Complete.ttf?raw=true --output "src/glyphs/Symbols-2048-em Nerd Font Complete.ttf"
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/Unicode_IEC_symbol_font.otf?raw=true --output src/glyphs//Unicode_IEC_symbol_font.otf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/devicons.ttf?raw=true --output src/glyphs/devicons.ttf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/font-awesome-extension.ttf?raw=true --output src/glyphs/font-awesome-extension.ttf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/font-logos.ttf?raw=true --output src/glyphs/font-logos.ttf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/materialdesignicons-webfont.ttf?raw=true --output src/glyphs/materialdesignicons-webfont.ttf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/octicons.ttf?raw=true --output src/glyphs/octicons.ttf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/original-source.otf?raw=true --output src/glyphs/original-source.otf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/master/src/glyphs/weathericons-regular-webfont.ttf?raw=true --output src/glyphs/weathericons-regular-webfont.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/FontAwesome.otf?raw=true --output src/glyphs/FontAwesome.otf
+curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v2.1.0/src/glyphs/NerdFontsSymbols%201000%20EM%20Nerd%20Font%20Complete%20Blank.sfd --output "src/glyphs/NerdFontsSymbols 1000 EM Nerd Font Complete Blank.sfd"
+curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v2.1.0/src/glyphs/NerdFontsSymbols%202048%20EM%20Nerd%20Font%20Complete%20Blank.sfd --output "src/glyphs/NerdFontsSymbols 2048 EM Nerd Font Complete Blank.sfd"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Pomicons.otf?raw=true --output src/glyphs/Pomicons.otf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/PowerlineExtraSymbols.otf?raw=true --output src/glyphs/PowerlineExtraSymbols.otf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/PowerlineSymbols.otf?raw=true --output src/glyphs/PowerlineSymbols.otf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Symbols%20Template%201000%20em.ttf?raw=true --output "src/glyphs/Symbols Template 1000 em.ttf"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Symbols%20Template%202048%20em.ttf?raw=true --output "src/glyphs/Symbols Template 2048 em.ttf"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Symbols-1000-em%20Nerd%20Font%20Complete.ttf?raw=true --output "src/glyphs/Symbols-1000-em Nerd Font Complete.ttf"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Symbols-2048-em%20Nerd%20Font%20Complete.ttf?raw=true --output "src/glyphs/Symbols-2048-em Nerd Font Complete.ttf"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Unicode_IEC_symbol_font.otf?raw=true --output src/glyphs//Unicode_IEC_symbol_font.otf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/devicons.ttf?raw=true --output src/glyphs/devicons.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/font-awesome-extension.ttf?raw=true --output src/glyphs/font-awesome-extension.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/font-logos.ttf?raw=true --output src/glyphs/font-logos.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/materialdesignicons-webfont.ttf?raw=true --output src/glyphs/materialdesignicons-webfont.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/octicons.ttf?raw=true --output src/glyphs/octicons.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/original-source.otf?raw=true --output src/glyphs/original-source.otf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/weathericons-regular-webfont.ttf?raw=true --output src/glyphs/weathericons-regular-webfont.ttf

--- a/download-source-fonts.sh
+++ b/download-source-fonts.sh
@@ -20,3 +20,4 @@ curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/materiald
 curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/octicons.ttf?raw=true --output src/glyphs/octicons.ttf
 curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/original-source.otf?raw=true --output src/glyphs/original-source.otf
 curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/weathericons-regular-webfont.ttf?raw=true --output src/glyphs/weathericons-regular-webfont.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/unpatched-fonts/Hack/Regular/Hack-Regular.ttf?raw=true --output src/glyphs/Hack-Regular.ttf

--- a/extract-math-glyphs
+++ b/extract-math-glyphs
@@ -1,0 +1,5 @@
+Open("src/glyphs/Hack-Regular.ttf");
+SelectAll();
+SelectFewer(0u2262,0u2263);
+Clear();
+Generate("src/glyphs/SomeMathSymbols.otf");


### PR DESCRIPTION
These glyphs have been asked for by issue #22 and #26. People using powerline and git usually have them in the default config, but that breaks in some Windows shells.

This is not as thoroughly tested on all platforms as I would wish, unfortunately.

[why]
Using powerline with git sometimes needs the glyphs
 - 0u2262   not identical to
 - 0u2263   strictly equivalent to

Usually they are provided by other installed fonts and the system's font
rendering mechanism should handle that. But that does not work on some
Windows applications that work as shells like ``PowerShell`` and ``Cmdr``

[how]
Grab these glyphs from a differnt font (i.e. [Hack](https://github.com/source-foundry/Hack)) which is included in Nerd Fonts' repo and patch it into our destination font. Nerd Fonts does not patch these into fonts, usually.

[note]
This PR depends (in fact includes) PR #27. I can not properly separate them because because of github limitations, sorry (or I'm too dump).