### PR TITLE
Make referenced Nerd Font release a parameter

### DIFF
--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      NERDFONTVERS: v2.1.0
     steps:
     - uses: actions/checkout@v1
     - name: Download latest version of Cascadia
@@ -14,7 +16,7 @@ jobs:
         sudo add-apt-repository ppa:fontforge/fontforge -y -u;
         sudo apt-get install fontforge -y;
     - name: Download Font Patcher
-      run: curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v2.1.0/font-patcher --output font-patcher
+      run: curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/${NERDFONTVERS}/font-patcher --output font-patcher
     - name: Download source fonts
       run: |
         chmod +x download-source-fonts.sh

--- a/download-source-fonts.sh
+++ b/download-source-fonts.sh
@@ -2,22 +2,22 @@
 
 mkdir -p src/glyphs
 
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/FontAwesome.otf?raw=true --output src/glyphs/FontAwesome.otf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/NerdFontsSymbols%201000%20EM%20Nerd%20Font%20Complete%20Blank.sfd?raw=true --output "src/glyphs/NerdFontsSymbols 1000 EM Nerd Font Complete Blank.sfd"
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/NerdFontsSymbols%202048%20EM%20Nerd%20Font%20Complete%20Blank.sfd?raw=true --output "src/glyphs/NerdFontsSymbols 2048 EM Nerd Font Complete Blank.sfd"
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Pomicons.otf?raw=true --output src/glyphs/Pomicons.otf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/PowerlineExtraSymbols.otf?raw=true --output src/glyphs/PowerlineExtraSymbols.otf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/PowerlineSymbols.otf?raw=true --output src/glyphs/PowerlineSymbols.otf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Symbols%20Template%201000%20em.ttf?raw=true --output "src/glyphs/Symbols Template 1000 em.ttf"
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Symbols%20Template%202048%20em.ttf?raw=true --output "src/glyphs/Symbols Template 2048 em.ttf"
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Symbols-1000-em%20Nerd%20Font%20Complete.ttf?raw=true --output "src/glyphs/Symbols-1000-em Nerd Font Complete.ttf"
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Symbols-2048-em%20Nerd%20Font%20Complete.ttf?raw=true --output "src/glyphs/Symbols-2048-em Nerd Font Complete.ttf"
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Unicode_IEC_symbol_font.otf?raw=true --output src/glyphs//Unicode_IEC_symbol_font.otf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/devicons.ttf?raw=true --output src/glyphs/devicons.ttf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/font-awesome-extension.ttf?raw=true --output src/glyphs/font-awesome-extension.ttf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/font-logos.ttf?raw=true --output src/glyphs/font-logos.ttf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/materialdesignicons-webfont.ttf?raw=true --output src/glyphs/materialdesignicons-webfont.ttf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/octicons.ttf?raw=true --output src/glyphs/octicons.ttf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/original-source.otf?raw=true --output src/glyphs/original-source.otf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/weathericons-regular-webfont.ttf?raw=true --output src/glyphs/weathericons-regular-webfont.ttf
-curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/unpatched-fonts/Hack/Regular/Hack-Regular.ttf?raw=true --output src/glyphs/Hack-Regular.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/FontAwesome.otf?raw=true --output src/glyphs/FontAwesome.otf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/NerdFontsSymbols%201000%20EM%20Nerd%20Font%20Complete%20Blank.sfd --output "src/glyphs/NerdFontsSymbols 1000 EM Nerd Font Complete Blank.sfd"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/NerdFontsSymbols%202048%20EM%20Nerd%20Font%20Complete%20Blank.sfd --output "src/glyphs/NerdFontsSymbols 2048 EM Nerd Font Complete Blank.sfd"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/Pomicons.otf?raw=true --output src/glyphs/Pomicons.otf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/PowerlineExtraSymbols.otf?raw=true --output src/glyphs/PowerlineExtraSymbols.otf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/PowerlineSymbols.otf?raw=true --output src/glyphs/PowerlineSymbols.otf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/Symbols%20Template%201000%20em.ttf?raw=true --output "src/glyphs/Symbols Template 1000 em.ttf"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/Symbols%20Template%202048%20em.ttf?raw=true --output "src/glyphs/Symbols Template 2048 em.ttf"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/Symbols-1000-em%20Nerd%20Font%20Complete.ttf?raw=true --output "src/glyphs/Symbols-1000-em Nerd Font Complete.ttf"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/Symbols-2048-em%20Nerd%20Font%20Complete.ttf?raw=true --output "src/glyphs/Symbols-2048-em Nerd Font Complete.ttf"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/Unicode_IEC_symbol_font.otf?raw=true --output src/glyphs//Unicode_IEC_symbol_font.otf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/devicons.ttf?raw=true --output src/glyphs/devicons.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/font-awesome-extension.ttf?raw=true --output src/glyphs/font-awesome-extension.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/font-logos.ttf?raw=true --output src/glyphs/font-logos.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/materialdesignicons-webfont.ttf?raw=true --output src/glyphs/materialdesignicons-webfont.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/octicons.ttf?raw=true --output src/glyphs/octicons.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/original-source.otf?raw=true --output src/glyphs/original-source.otf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/glyphs/weathericons-regular-webfont.ttf?raw=true --output src/glyphs/weathericons-regular-webfont.ttf
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/${NERDFONTVERS}/src/unpatched-fonts/Hack/Regular/Hack-Regular.ttf?raw=true --output src/glyphs/Hack-Regular.ttf

--- a/download-source-fonts.sh
+++ b/download-source-fonts.sh
@@ -3,8 +3,8 @@
 mkdir -p src/glyphs
 
 curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/FontAwesome.otf?raw=true --output src/glyphs/FontAwesome.otf
-curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v2.1.0/src/glyphs/NerdFontsSymbols%201000%20EM%20Nerd%20Font%20Complete%20Blank.sfd --output "src/glyphs/NerdFontsSymbols 1000 EM Nerd Font Complete Blank.sfd"
-curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v2.1.0/src/glyphs/NerdFontsSymbols%202048%20EM%20Nerd%20Font%20Complete%20Blank.sfd --output "src/glyphs/NerdFontsSymbols 2048 EM Nerd Font Complete Blank.sfd"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/NerdFontsSymbols%201000%20EM%20Nerd%20Font%20Complete%20Blank.sfd?raw=true --output "src/glyphs/NerdFontsSymbols 1000 EM Nerd Font Complete Blank.sfd"
+curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/NerdFontsSymbols%202048%20EM%20Nerd%20Font%20Complete%20Blank.sfd?raw=true --output "src/glyphs/NerdFontsSymbols 2048 EM Nerd Font Complete Blank.sfd"
 curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/Pomicons.otf?raw=true --output src/glyphs/Pomicons.otf
 curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/PowerlineExtraSymbols.otf?raw=true --output src/glyphs/PowerlineExtraSymbols.otf
 curl -L https://github.com/ryanoasis/nerd-fonts/blob/v2.1.0/src/glyphs/PowerlineSymbols.otf?raw=true --output src/glyphs/PowerlineSymbols.otf


### PR DESCRIPTION
**[why]**
The Nerd Font revision is given in a lot of places. It is better to
specify data once instead of multiple times, so give it in a central
place instead.
    
**[how]**
Use an environment variable to carry the information to all affected
places (i.e. curl downloads).

**[note]**
I have no yaml setup locally, so I have to test this with the PR triggered CI.
Hopefully it will work ;->