### PR TITLE
Add 0u276F from Hack

### DIFF
--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -26,10 +26,10 @@ jobs:
     - name: Install configparser
       run: pip install configparser
     - name: Extract additional powerline glyphs
-      run: fontforge -lang=ff -script extract-math-glyphs
+      run: fontforge -lang=ff -script extract-extra-glyphs
     - name: Build Powerline
       run: |
-        fontforge -script font-patcher --careful --powerline --custom SomeMathSymbols.otf \
+        fontforge -script font-patcher --careful --powerline --custom SomeExtraSymbols.otf \
                                        --no-progressbars --mono Cascadia.ttf | tee process.log
         git describe --always --tags | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Mono.ttf \
                                                             --output "Delugia Nerd Font.ttf" \
@@ -37,7 +37,7 @@ jobs:
                                                             --version
     - name: Build Complete
       run: |
-        fontforge -script font-patcher --careful -c --custom SomeMathSymbols.otf \
+        fontforge -script font-patcher --careful -c --custom SomeExtraSymbols.otf \
                                        --no-progressbars --mono Cascadia.ttf | tee process_full.log
         git describe --always --tags | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Complete\ Mono.ttf \
                                                             --output "Delugia Nerd Font Complete.ttf" \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ _Complete_ includes these symbols additionally:
 ### How is Delugia special?
 Compared with other patched versions of Cascadia you will find
 * Backtick char `` ` `` working in ligature enabled environments
-* Added symbols ``≢`` (0u2262) and ``≣`` (0u2263) used with some popular Powerline setups
+* Added symbols ``≢`` (0u2262), ``≣`` (0u2263), and ``❯`` (0u276F) used with some popular Powerline setups
 
 ### How to use
 You can download the patched font from the [Releases page](https://github.com/adam7/delugia-code/releases) of this repo and install them as you would any other font. Once installed the font can be referenced as `Delugia Nerd Font`. So if, for example, you want to use it in Windows Terminal you should add this line to your profiles.json

--- a/extract-extra-glyphs
+++ b/extract-extra-glyphs
@@ -2,4 +2,4 @@ Open("src/glyphs/Hack-Regular.ttf");
 SelectAll();
 SelectFewer(0u2262,0u2263);
 Clear();
-Generate("src/glyphs/SomeMathSymbols.otf");
+Generate("src/glyphs/SomeExtraSymbols.otf");

--- a/extract-extra-glyphs
+++ b/extract-extra-glyphs
@@ -1,5 +1,6 @@
 Open("src/glyphs/Hack-Regular.ttf");
 SelectAll();
 SelectFewer(0u2262,0u2263);
+SelectFewer(0u276F);
 Clear();
 Generate("src/glyphs/SomeExtraSymbols.otf");


### PR DESCRIPTION
**[why]**
0u276F ``❯`` => Heavy right-pointing angle quotation mark ornament
This is another frequently used glyph.
    
**[how]**
Just add to list of to-copy glyphs.
    
Fixes: #25
