### PR TITLE
Add non-monospaced (Book) variant of 'complete'

### DIFF
--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -43,6 +43,14 @@ jobs:
                                                             --output "Delugia Nerd Font Complete.ttf" \
                                                             --name "Delugia Nerd Font" \
                                                             --version
+    - name: Build Book Complete
+      run: |
+        fontforge -script font-patcher --careful -c --custom SomeExtraSymbols.otf \
+                                       --no-progressbars Cascadia.ttf | tee process_book.log
+        git describe --always --tags | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Complete.ttf \
+                                                            --output "Delugia Nerd Font Book.ttf" \
+                                                            --name "Delugia Nerd Font Book" \
+                                                            --version
     - name: Check for preexisting glyphs
       run: |
         grep 'Found existing' process*.log
@@ -54,6 +62,10 @@ jobs:
       with:
         name: Delugia Nerd Font Complete
         path: "Delugia Nerd Font Complete.ttf"
+    - uses: actions/upload-artifact@master
+      with:
+        name: Delugia Nerd Font Book
+        path: "Delugia Nerd Font Book.ttf"
     - name: Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
@@ -61,5 +73,6 @@ jobs:
         files: |
           Delugia Nerd Font.ttf
           Delugia Nerd Font Complete.ttf
+          Delugia Nerd Font Book.ttf
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ _Complete_ includes these symbols additionally:
 * [Font Logos](https://github.com/Lukas-W/font-logos)
 * [Octicons](https://github.com/github/octicons)
 
+### Which font faces are available
+These three faces are generated:
+* **Delugia Nerd Font Powerline** _Basic glyphs, monospaced font_
+* **Delugia Nerd Font Complete** _All Nerd Fonts glyphs, monospaced font_
+* **Delugia Nerd Font Book** _All Nerd Fonts glyphs, propotional font (not recommended for coding/console)_
+
 ### How is Delugia special?
 Compared with other patched versions of Cascadia you will find
 * Backtick char `` ` `` working in ligature enabled environments


### PR DESCRIPTION
This adds all the extra symbols not re-scaled as a Book font.
Fixes #31.

I'm not sure if we want this, though. On the other hand, what is the risk.

But we would need to touch [scoop nerd fonts](https://github.com/matthewjberger/scoop-nerd-fonts) yet again, because:
1. we again have a release
2. another font face is added

**[why]**
Sometimes it would be nice to be not limited in character width to the
monospace corset. This enables the symbols to be bigger in size for a
visually more pleasing occurrence.

**[how]**
Just create a font without re-sizeing (no --mono option with
font-patcher).
