### PR TITLE
Adapt to new Cascadia release scheme

### DIFF
--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -15,7 +15,7 @@ jobs:
         echo Downloading ${CASCADIAVERS}
         curl -L https://github.com/microsoft/cascadia-code/releases/download/${CASCADIAVERS}  -O
         unzip CascadiaCode*.zip
-        mv **/CascadiaCode.ttf .
+        mv **/CascadiaCodePL.ttf .
     - name: Install FontForge
       run: |
         sudo add-apt-repository ppa:fontforge/fontforge -y -u;

--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -10,7 +10,12 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Download latest version of Cascadia
-      run: curl -L https://github.com/microsoft/cascadia-code/releases/latest/download/Cascadia.ttf  --output Cascadia.ttf
+      run: |
+        CASCADIAVERS=`curl -L 'https://github.com/microsoft/cascadia-code/releases/latest' | grep CascadiaCode | sed 's!\(.*/microsoft/cascadia-code/releases/download/\([^"]*\).*\|.*span.*\)!\2!'`
+        echo Downloading ${CASCADIAVERS}
+        curl -L https://github.com/microsoft/cascadia-code/releases/download/${CASCADIAVERS}  -O
+        unzip CascadiaCode*.zip
+        mv **/CascadiaCode.ttf .
     - name: Install FontForge
       run: |
         sudo add-apt-repository ppa:fontforge/fontforge -y -u;
@@ -30,7 +35,7 @@ jobs:
     - name: Build Powerline
       run: |
         fontforge -script font-patcher --careful --powerline --custom SomeExtraSymbols.otf \
-                                       --no-progressbars --mono Cascadia.ttf | tee process.log
+                                       --no-progressbars --mono Cascadia*.ttf | tee process.log
         git describe --always --tags | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Mono.ttf \
                                                             --output "Delugia Nerd Font.ttf" \
                                                             --name "Delugia Nerd Font" \
@@ -38,7 +43,7 @@ jobs:
     - name: Build Complete
       run: |
         fontforge -script font-patcher --careful -c --custom SomeExtraSymbols.otf \
-                                       --no-progressbars --mono Cascadia.ttf | tee process_full.log
+                                       --no-progressbars --mono Cascadia*.ttf | tee process_full.log
         git describe --always --tags | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Complete\ Mono.ttf \
                                                             --output "Delugia Nerd Font Complete.ttf" \
                                                             --name "Delugia Nerd Font" \
@@ -46,7 +51,7 @@ jobs:
     - name: Build Book Complete
       run: |
         fontforge -script font-patcher --careful -c --custom SomeExtraSymbols.otf \
-                                       --no-progressbars Cascadia.ttf | tee process_book.log
+                                       --no-progressbars Cascadia*.ttf | tee process_book.log
         git describe --always --tags | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Complete.ttf \
                                                             --output "Delugia Nerd Font Book.ttf" \
                                                             --name "Delugia Nerd Font Book" \


### PR DESCRIPTION
**[why]**
Microsoft changed the release mechanism.
Instead of directly releasing the font files they are packed into a zip
archive now, in different formats.

Further complication is that the release version name is also in the zip
archive name, so we can not directly download it anymore in a generic
way.

**[how]**
First fetch the latest-release website and try to cut out the latest
release's directory and release package name.

Use that to download the archive. Unpack it and pull the font out.

This is all not so nice, but I see no other way to stay halfway generic
with their release scheme. And this just hopes, that they do not change
it again the next time :-/

This fixes #33

Please check if the resulting font(s) are ok @chunliu. I will generate a new release package if you find this working.