### PR TITLE
Generate Delugia font from CascadiaMonoPL

### DIFF
--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -33,44 +33,50 @@ jobs:
       run: fontforge -lang=ff -script extract-extra-glyphs
     - name: Prepare Cascadia Code font file
       run: |
-        fontforge prepare-font --input ttf/CascadiaCodePL.ttf --output CascadiaCodePL.ttf
-        fontforge prepare-font --input ttf/CascadiaMonoPL.ttf --output CascadiaMonoPL.ttf
+        mkdir prepared
+        fontforge prepare-font --input ttf/CascadiaCodePL.ttf --output prepared/CascadiaCodePL.ttf
+        fontforge prepare-font --input ttf/CascadiaMonoPL.ttf --output prepared/CascadiaMonoPL.ttf
     - name: Build Powerline
       run: |
         fontforge -script font-patcher --careful --powerline --custom SomeExtraSymbols.otf \
-                                       --no-progressbars --mono CascadiaCodePL.ttf | tee process.log
-        git describe --always --tags | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Mono.ttf \
-                                                            --output "Delugia Nerd Font.ttf" \
+                                       --no-progressbars --mono prepared/CascadiaCodePL.ttf | tee process.log
+        git describe --always --tags | xargs fontforge rename-font --input C*.ttf \
+                                                                    --output "Delugia Nerd Font.ttf" \
                                                             --name "Delugia Nerd Font" \
                                                             --version
+        rm C*.ttf
         fontforge -script font-patcher --careful --powerline --custom SomeExtraSymbols.otf \
-                                       --no-progressbars --mono CascadiaMonoPL.ttf | tee process_mono.log
-        git describe --always --tags | xargs fontforge rename-font --input "Cascadia Mono PL Nerd Font Mono.ttf" \
+                                       --no-progressbars --mono prepared/CascadiaMonoPL.ttf | tee process_mono.log
+        git describe --always --tags | xargs fontforge rename-font --input C*.ttf \
                                                             --output "Delugia Mono Nerd Font.ttf" \
                                                             --name "Delugia Mono Nerd Font" \
                                                             --version
+        rm C*.ttf
     - name: Build Complete
       run: |
         fontforge -script font-patcher --careful -c --custom SomeExtraSymbols.otf \
-                                       --no-progressbars --mono CascadiaCodePL.ttf | tee process_full.log
-        git describe --always --tags | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Complete\ Mono.ttf \
+                                       --no-progressbars --mono prepared/CascadiaCodePL.ttf | tee process_full.log
+        git describe --always --tags | xargs fontforge rename-font --input C*.ttf \
                                                             --output "Delugia Nerd Font Complete.ttf" \
                                                             --name "Delugia Nerd Font" \
                                                             --version
+        rm C*.ttf
         fontforge -script font-patcher --careful -c --custom SomeExtraSymbols.otf \
-                                       --no-progressbars --mono CascadiaMonoPL.ttf | tee process_mono_full.log
-        git describe --always --tags | xargs fontforge rename-font --input "Cascadia Mono PL Nerd Font Complete Mono.ttf" \
+                                       --no-progressbars --mono prepared/CascadiaMonoPL.ttf | tee process_mono_full.log
+        git describe --always --tags | xargs fontforge rename-font --input C*.ttf \
                                                             --output "Delugia Mono Nerd Font Complete.ttf" \
                                                             --name "Delugia Mono Nerd Font" \
                                                             --version
+        rm C*.ttf
     - name: Build Book Complete
       run: |
         fontforge -script font-patcher --careful -c --custom SomeExtraSymbols.otf \
-                                       --no-progressbars CascadiaCodePL.ttf | tee process_book.log
-        git describe --always --tags | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Complete.ttf \
+                                       --no-progressbars prepared/CascadiaCodePL.ttf | tee process_book.log
+        git describe --always --tags | xargs fontforge rename-font --input C*.ttf \
                                                             --output "Delugia Nerd Font Book.ttf" \
                                                             --name "Delugia Nerd Font Book" \
                                                             --version
+        rm C*.ttf
     - name: Check for preexisting glyphs
       run: |
         grep 'Found existing' process*.log

--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -45,7 +45,7 @@ jobs:
                                                             --version
         fontforge -script font-patcher --careful --powerline --custom SomeExtraSymbols.otf \
                                        --no-progressbars --mono CascadiaMonoPL.ttf | tee process_mono.log
-        git describe --always --tags | xargs fontforge rename-font --input "Cascadia Mono PL Regular Nerd Font Mono.ttf" \
+        git describe --always --tags | xargs fontforge rename-font --input "Cascadia Mono PL Nerd Font Mono.ttf" \
                                                             --output "Delugia Mono Nerd Font.ttf" \
                                                             --name "Delugia Mono Nerd Font" \
                                                             --version
@@ -59,7 +59,7 @@ jobs:
                                                             --version
         fontforge -script font-patcher --careful -c --custom SomeExtraSymbols.otf \
                                        --no-progressbars --mono CascadiaMonoPL.ttf | tee process_mono_full.log
-        git describe --always --tags | xargs fontforge rename-font --input "Cascadia Mono PL Regular Nerd Font Complete Mono.ttf" \
+        git describe --always --tags | xargs fontforge rename-font --input "Cascadia Mono PL Nerd Font Complete Mono.ttf" \
                                                             --output "Delugia Mono Nerd Font Complete.ttf" \
                                                             --name "Delugia Mono Nerd Font" \
                                                             --version

--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -71,12 +71,6 @@ jobs:
                                                             --output "Delugia Nerd Font Book.ttf" \
                                                             --name "Delugia Nerd Font Book" \
                                                             --version
-        fontforge -script font-patcher --careful -c --custom SomeExtraSymbols.otf \
-                                       --no-progressbars CascadiaMonoPL.ttf | tee process_book.log
-        git describe --always --tags | xargs fontforge rename-font --input "Cascadia Mono PL Regular Nerd Font Complete.ttf" \
-                                                            --output "Delugia Mono Nerd Font Book.ttf" \
-                                                            --name "Delugia Mono Nerd Font Book" \
-                                                            --version
     - name: Check for preexisting glyphs
       run: |
         grep 'Found existing' process*.log
@@ -100,10 +94,6 @@ jobs:
       with:
         name: Delugia Mono Nerd Font Complete
         path: "Delugia Mono Nerd Font Complete.ttf"
-    - uses: actions/upload-artifact@master
-      with:
-        name: Delugia Mono Nerd Font Book
-        path: "Delugia Mono Nerd Font Book.ttf"
     - name: Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
@@ -114,6 +104,5 @@ jobs:
           Delugia Nerd Font Book.ttf
           Delugia Mono Nerd Font.ttf
           Delugia Mono Nerd Font Complete.ttf
-          Delugia Mono Nerd Font Book.ttf
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         fontforge -script font-patcher --careful --powerline --custom SomeExtraSymbols.otf \
                                        --no-progressbars --mono CascadiaCodePL.ttf | tee process.log
-        git describe --always --tags | xargs fontforge rename-font --input "Caskaydia Cove PL Regular Nerd Font Mono.ttf" \
+        git describe --always --tags | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Mono.ttf \
                                                             --output "Delugia Nerd Font.ttf" \
                                                             --name "Delugia Nerd Font" \
                                                             --version
@@ -53,7 +53,7 @@ jobs:
       run: |
         fontforge -script font-patcher --careful -c --custom SomeExtraSymbols.otf \
                                        --no-progressbars --mono CascadiaCodePL.ttf | tee process_full.log
-        git describe --always --tags | xargs fontforge rename-font --input "Caskaydia Cove PL Regular Nerd Font Complete Mono.ttf" \
+        git describe --always --tags | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Complete\ Mono.ttf \
                                                             --output "Delugia Nerd Font Complete.ttf" \
                                                             --name "Delugia Nerd Font" \
                                                             --version
@@ -67,7 +67,7 @@ jobs:
       run: |
         fontforge -script font-patcher --careful -c --custom SomeExtraSymbols.otf \
                                        --no-progressbars CascadiaCodePL.ttf | tee process_book.log
-        git describe --always --tags | xargs fontforge rename-font --input "Caskaydia Cove PL Regular Nerd Font Complete.ttf" \
+        git describe --always --tags | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Complete.ttf \
                                                             --output "Delugia Nerd Font Book.ttf" \
                                                             --name "Delugia Nerd Font Book" \
                                                             --version

--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -44,7 +44,7 @@ jobs:
                                                             --name "Delugia Nerd Font" \
                                                             --version
         fontforge -script font-patcher --careful --powerline --custom SomeExtraSymbols.otf \
-                                       --no-progressbars --mono CascadiaMonoPL.ttf | tee process.log
+                                       --no-progressbars --mono CascadiaMonoPL.ttf | tee process_mono.log
         git describe --always --tags | xargs fontforge rename-font --input "Cascadia Mono PL Regular Nerd Font Mono.ttf" \
                                                             --output "Delugia Mono Nerd Font.ttf" \
                                                             --name "Delugia Mono Nerd Font" \
@@ -58,7 +58,7 @@ jobs:
                                                             --name "Delugia Nerd Font" \
                                                             --version
         fontforge -script font-patcher --careful -c --custom SomeExtraSymbols.otf \
-                                       --no-progressbars --mono CascadiaMonoPL.ttf | tee process_full.log
+                                       --no-progressbars --mono CascadiaMonoPL.ttf | tee process_mono_full.log
         git describe --always --tags | xargs fontforge rename-font --input "Cascadia Mono PL Regular Nerd Font Complete Mono.ttf" \
                                                             --output "Delugia Mono Nerd Font Complete.ttf" \
                                                             --name "Delugia Mono Nerd Font" \

--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -31,31 +31,51 @@ jobs:
       run: pip install configparser
     - name: Extract additional powerline glyphs
       run: fontforge -lang=ff -script extract-extra-glyphs
-    - name: Prepare Caskadia Code font file
-      run: fontforge prepare-font --input **/CascadiaCodePL.ttf --output CascadiaCodePL.ttf
+    - name: Prepare Cascadia Code font file
+      run: |
+        fontforge prepare-font --input ttf/CascadiaCodePL.ttf --output CascadiaCodePL.ttf
+        fontforge prepare-font --input ttf/CascadiaMonoPL.ttf --output CascadiaMonoPL.ttf
     - name: Build Powerline
       run: |
         fontforge -script font-patcher --careful --powerline --custom SomeExtraSymbols.otf \
-                                       --no-progressbars --mono Cascadia*.ttf | tee process.log
-        git describe --always --tags | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Mono.ttf \
+                                       --no-progressbars --mono CascadiaCodePL.ttf | tee process.log
+        git describe --always --tags | xargs fontforge rename-font --input "Caskaydia Cove PL Regular Nerd Font Mono.ttf" \
                                                             --output "Delugia Nerd Font.ttf" \
                                                             --name "Delugia Nerd Font" \
+                                                            --version
+        fontforge -script font-patcher --careful --powerline --custom SomeExtraSymbols.otf \
+                                       --no-progressbars --mono CascadiaMonoPL.ttf | tee process.log
+        git describe --always --tags | xargs fontforge rename-font --input "Cascadia Mono PL Regular Nerd Font Mono.ttf" \
+                                                            --output "Delugia Mono Nerd Font.ttf" \
+                                                            --name "Delugia Mono Nerd Font" \
                                                             --version
     - name: Build Complete
       run: |
         fontforge -script font-patcher --careful -c --custom SomeExtraSymbols.otf \
-                                       --no-progressbars --mono Cascadia*.ttf | tee process_full.log
-        git describe --always --tags | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Complete\ Mono.ttf \
+                                       --no-progressbars --mono CascadiaCodePL.ttf | tee process_full.log
+        git describe --always --tags | xargs fontforge rename-font --input "Caskaydia Cove PL Regular Nerd Font Complete Mono.ttf" \
                                                             --output "Delugia Nerd Font Complete.ttf" \
                                                             --name "Delugia Nerd Font" \
+                                                            --version
+        fontforge -script font-patcher --careful -c --custom SomeExtraSymbols.otf \
+                                       --no-progressbars --mono CascadiaMonoPL.ttf | tee process_full.log
+        git describe --always --tags | xargs fontforge rename-font --input "Cascadia Mono PL Regular Nerd Font Complete Mono.ttf" \
+                                                            --output "Delugia Mono Nerd Font Complete.ttf" \
+                                                            --name "Delugia Mono Nerd Font" \
                                                             --version
     - name: Build Book Complete
       run: |
         fontforge -script font-patcher --careful -c --custom SomeExtraSymbols.otf \
-                                       --no-progressbars Cascadia*.ttf | tee process_book.log
-        git describe --always --tags | xargs fontforge rename-font --input Cas*\ Nerd\ Font\ Complete.ttf \
+                                       --no-progressbars CascadiaCodePL.ttf | tee process_book.log
+        git describe --always --tags | xargs fontforge rename-font --input "Caskaydia Cove PL Regular Nerd Font Complete.ttf" \
                                                             --output "Delugia Nerd Font Book.ttf" \
                                                             --name "Delugia Nerd Font Book" \
+                                                            --version
+        fontforge -script font-patcher --careful -c --custom SomeExtraSymbols.otf \
+                                       --no-progressbars CascadiaMonoPL.ttf | tee process_book.log
+        git describe --always --tags | xargs fontforge rename-font --input "Cascadia Mono PL Regular Nerd Font Complete.ttf" \
+                                                            --output "Delugia Mono Nerd Font Book.ttf" \
+                                                            --name "Delugia Mono Nerd Font Book" \
                                                             --version
     - name: Check for preexisting glyphs
       run: |
@@ -72,6 +92,18 @@ jobs:
       with:
         name: Delugia Nerd Font Book
         path: "Delugia Nerd Font Book.ttf"
+    - uses: actions/upload-artifact@master
+      with:
+        name: Delugia Mono Nerd Font Powerline
+        path: "Delugia Mono Nerd Font.ttf"
+    - uses: actions/upload-artifact@master
+      with:
+        name: Delugia Mono Nerd Font Complete
+        path: "Delugia Mono Nerd Font Complete.ttf"
+    - uses: actions/upload-artifact@master
+      with:
+        name: Delugia Mono Nerd Font Book
+        path: "Delugia Mono Nerd Font Book.ttf"
     - name: Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
@@ -80,5 +112,8 @@ jobs:
           Delugia Nerd Font.ttf
           Delugia Nerd Font Complete.ttf
           Delugia Nerd Font Book.ttf
+          Delugia Mono Nerd Font.ttf
+          Delugia Mono Nerd Font Complete.ttf
+          Delugia Mono Nerd Font Book.ttf
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -36,10 +36,16 @@ _Complete_ includes these symbols additionally:
 * [Octicons](https://github.com/github/octicons)
 
 ### Which font faces are available
-These three faces are generated:
+Cascadia now bundles a version without ligatures, called Cascadia Mono, in addition to Cascadia Code which has ligatures.
+
+These three faces are generated from Cascadia Code:
 * **Delugia Nerd Font Powerline** _Basic glyphs, monospaced font_
 * **Delugia Nerd Font Complete** _All Nerd Fonts glyphs, monospaced font_
 * **Delugia Nerd Font Book** _All Nerd Fonts glyphs, proportional font (not recommended for coding/console)_
+
+And the following two faces are generated from Cascadia Mono and don't have ligatures:
+* **Delugia Mono Nerd Font Powerline** _Basic glyphs, monospaced font_
+* **Delugia Mono Nerd Font Complete** _All Nerd Fonts glyphs, monospaced font_
 
 ### How is Delugia special?
 Compared with other patched versions of Cascadia you will find


### PR DESCRIPTION
This PR extends font generation workflow to produce "Delugia Mono" font from CascadiaMonoPL.

Cascadia Mono is the version of Cascadia Code without ligatures. Supporting it may be useful for those environments that don't allow disabling ligatures (e.g. Windows Terminal).

The workflow now produces two additional fonts:
- Delugia Mono Nerd Font.ttf
- Delugia Mono Nerd Font Complete.ttf