### PR TITLE
Bugfix/fix font logos

### DIFF
--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -19,8 +19,10 @@ jobs:
       run: |
         sudo add-apt-repository ppa:fontforge/fontforge -y -u;
         sudo apt-get install fontforge -y;
-    - name: Download Font Patcher
-      run: curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/${NERDFONTVERS}/font-patcher --output font-patcher
+    - name: Download and patch Font Patcher
+      run: |
+        curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/${NERDFONTVERS}/font-patcher --output font-patcher
+        patch font-patcher 0001*.patch
     - name: Download source fonts
       run: |
         chmod +x download-source-fonts.sh

--- a/0001-font-patcher-Do-not-valign-non-monospaced-fonts.patch
+++ b/0001-font-patcher-Do-not-valign-non-monospaced-fonts.patch
@@ -1,0 +1,48 @@
+From 427f950115135c3ea76c3b2d46105170e258c14d Mon Sep 17 00:00:00 2001
+From: Fini Jastrow <ulf.fini.jastrow@desy.de>
+Date: Sun, 14 Mar 2021 21:53:06 +0100
+Subject: [PATCH] font-patcher: Do not valign non-monospaced fonts
+
+[why]
+When glyphs are added to a monospaced font and these glyphs are bigger
+symbols (like on-off or logos) they need to be scaled down quite a bit
+(for normal target fonts that are higher than wide).
+These tiny symbols are then centered within the complete vertical hight
+(descent to ascent) to have them centered on the powerline triangle
+tips.
+
+When a non-monospace font is generated the symbols are not tiny anymore
+and often it is visually more pleasing to put them where they were
+intended to be put relative to the baseline - because usually the source
+fonts are well designed enough.
+
+[how]
+Do a vertical shift only on monospaced output fonts.
+
+This is in accordance with the line 711 comment:
+    # Now that we have copy/pasted the glyph, if we are creating a monospace
+    # font we need to scale and move the glyphs.
+
+-> Not scale and MOVE when non-monospaced.
+
+Signed-off-by: Fini Jastrow <ulf.fini.jastrow@desy.de>
+---
+ font-patcher | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/font-patcher b/font-patcher
+index aa701ce5..f1a99b36 100755
+--- a/font-patcher
++++ b/font-patcher
+@@ -750,7 +750,7 @@ class font_patcher:
+             # Use the dimensions from the newly pasted and stretched glyph
+             sym_dim = get_glyph_dimensions(self.sourceFont[currentSourceFontGlyph])
+             y_align_distance = 0
+-            if sym_attr['valign'] == 'c':
++            if self.args.single and sym_attr['valign'] == 'c':
+                 # Center the symbol vertically by matching the center of the line height and center of symbol
+                 sym_ycenter = sym_dim['ymax'] - (sym_dim['height'] / 2)
+                 font_ycenter = self.font_dim['ymax'] - (self.font_dim['height'] / 2)
+-- 
+2.27.0
+


### PR DESCRIPTION
In the _**Book**_ face a lot of the icon glyphs look too far up. Compare #53 

The reason is that `font-patcher` vertically centers most of the added glyphs.
This can not be changed without patching `font-patcher`.

This MR changes the output fonts so, that the glyphs added from **font logos** and the `git` textual glyph from **FontAwesome** is *not* vertically centered anymore but is kept on the baseline. There are several pictures showing the effect in the aforementioned issue.

The downside is, that the symbols are not centered anymore in the middle of the caps-height but rather stay in the x-height. There might be people that do not like the effect:

![image](https://user-images.githubusercontent.com/16012374/111076605-4a15f280-84ed-11eb-9200-de48c7e38321.png)

It is possible to change that behavior only for the _book_ face; but that is not foreseen in `font-patcher`, so that we end up with a  more invasive fix. But maybe that is the way to handle it.

Are there any opinions? What about the other (untouched by the MR) symbol glyphs in the **book** face? Are they all defective? That would call for another action (disable all vertical alignment if a proportional font is the patch target).