### PR TITLE
Correct vertical alignment of added glyphs

### DIFF
--- a/.github/workflows/generate-fonts.yml
+++ b/.github/workflows/generate-fonts.yml
@@ -19,8 +19,10 @@ jobs:
       run: |
         sudo add-apt-repository ppa:fontforge/fontforge -y -u;
         sudo apt-get install fontforge -y;
-    - name: Download Font Patcher
-      run: curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/${NERDFONTVERS}/font-patcher --output font-patcher
+    - name: Download and patch Font Patcher
+      run: |
+        curl -L https://raw.githubusercontent.com/ryanoasis/nerd-fonts/${NERDFONTVERS}/font-patcher --output font-patcher
+        patch font-patcher 0001*.patch
     - name: Download source fonts
       run: |
         chmod +x download-source-fonts.sh

--- a/0001-font-patcher-Use-correct-source-font-metrics.patch
+++ b/0001-font-patcher-Use-correct-source-font-metrics.patch
@@ -1,0 +1,44 @@
+From 65f2699fd80afb70b0374a2a83e1b7995245ee8f Mon Sep 17 00:00:00 2001
+From: Fini Jastrow <ulf.fini.jastrow@desy.de>
+Date: Tue, 16 Mar 2021 12:15:55 +0100
+Subject: [PATCH] font-patcher: Use correct source font metrics
+
+[why]
+With a source font where Win Ascent/Descent differs from Typo
+Ascend/Descent newly added symbols that are intended to be centered
+_within the visual space_ can end up too far up or down.
+
+The happens for example when patching CascadiaCode. Added glyphs like
+the Ubuntu logo (unicode 0xF31B) is not centered between the square
+brackets or on a line with the less then and other centered glyphs.
+
+[how]
+The calculation takes the Win Ascent/Descent to calculate the visual
+hight. That information is a mix of hight and line spacing and can be
+misleading.
+
+Therefore, if use_typo_metrics is set in a font, we obey that flag
+and use the typo metrics values instead.
+
+Signed-off-by: Fini Jastrow <ulf.fini.jastrow@desy.de>
+---
+ font-patcher | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/font-patcher b/font-patcher
+index aa701ce5..19bf13ba 100755
+--- a/font-patcher
++++ b/font-patcher
+@@ -572,6 +572,9 @@ class font_patcher:
+             'width' : 0,
+             'height': 0,
+         }
++        if self.sourceFont.os2_use_typo_metrics:
++            self.font_dim['ymin'] = self.sourceFont.os2_typodescent
++            self.font_dim['ymax'] = self.sourceFont.os2_typoascent
+ 
+         # Find the biggest char width
+         # Ignore the y-values, os2_winXXXXX values set above are used for line height
+-- 
+2.27.0
+


### PR DESCRIPTION
**[why]**
Added symbol glyphs like the Ubuntu logo 0xF31B appear too high.
At least they are not centered around the visual font center given by
square brackets, less then, minus, _and the powerline triangles
(0xE0B0).

**[how]**
The font-patcher script takes the 'Win Ascent' and 'Win Descent' values
to determine the visual height of the font (the space in which new
glyphs are centered).

For some reason (most probably the oversized overlapping box drawing
glyphs like unicode 0x2563) the 'Windows' values in Cascadia are far
greater than the HHead and Typo Metrics values.

Patch font-patcher to use the Typo Metrics values instead for a more
pleasing look.

Fixes: #53
Reported-by: Charles Roper <charles@roper.im>
Signed-off-by: Fini Jastrow <ulf.fini.jastrow@desy.de>