### PR TITLE
Fix wrong font flags

### DIFF
--- a/TableHEADWriter.py
+++ b/TableHEADWriter.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+# coding=utf8
+# Nerd Fonts Version: 2.3.3
+
+import sys
+
+class TableHEADWriter:
+    """ Access to the HEAD table without external dependencies """
+    def getlong(self, pos = None):
+        """ Get four bytes from the font file as integer number """
+        if pos:
+            self.goto(pos)
+        return (ord(self.f.read(1)) << 24) + (ord(self.f.read(1)) << 16) + (ord(self.f.read(1)) << 8) + ord(self.f.read(1))
+
+    def getshort(self, pos = None):
+        """ Get two bytes from the font file as integer number """
+        if pos:
+            self.goto(pos)
+        return (ord(self.f.read(1)) << 8) + ord(self.f.read(1))
+
+    def putlong(self, num, pos = None):
+        """ Put number as four bytes into font file """
+        if pos:
+            self.goto(pos)
+        self.f.write(bytearray([(num >> 24) & 0xFF, (num >> 16) & 0xFF ,(num >> 8) & 0xFF, num & 0xFF]))
+        self.modified = True
+
+    def putshort(self, num, pos = None):
+        """ Put number as two bytes into font file """
+        if pos:
+            self.goto(pos)
+        self.f.write(bytearray([(num >> 8) & 0xFF, num & 0xFF]))
+        self.modified = True
+
+    def calc_checksum(self, start, end, checksum = 0):
+        """ Calculate a font table checksum, optionally ignoring another embedded checksum value (for table 'head') """
+        self.f.seek(start)
+        for i in range(start, end - 4, 4):
+            checksum += self.getlong()
+            checksum &= 0xFFFFFFFF
+        i += 4
+        extra = 0
+        for j in range(4):
+            extra = extra << 8
+            if i + j <= end:
+                extra += ord(self.f.read(1))
+        checksum = (checksum + extra) & 0xFFFFFFFF
+        return checksum
+
+    def find_table(self, tablenames, idx):
+        """ Search all tables for one of the tables in tablenames and store its metadata """
+        # Use font with index idx if this is a font collection file
+        self.f.seek(0, 0)
+        tag = self.f.read(4)
+        if tag == b'ttcf':
+            self.f.seek(2*2, 1)
+            self.num_fonts = self.getlong()
+            if (idx >= self.num_fonts):
+                raise Exception('Trying to access subfont index {} but have only {} fonts'.format(idx, num_fonts))
+            for _ in range(idx + 1):
+                offset = self.getlong()
+            self.f.seek(offset, 0)
+        elif idx != 0:
+            raise Exception('Trying to access subfont but file is no collection')
+        else:
+            self.f.seek(0, 0)
+            self.num_fonts = 1
+
+        self.f.seek(4, 1)
+        numtables = self.getshort()
+        self.f.seek(3*2, 1)
+
+        for i in range(numtables):
+            tab_name = self.f.read(4)
+            self.tab_check_offset = self.f.tell()
+            self.tab_check = self.getlong()
+            self.tab_offset = self.getlong()
+            self.tab_length = self.getlong()
+            if tab_name in tablenames:
+                return True
+        return False
+
+    def find_head_table(self, idx):
+        """ Search all tables for the HEAD table and store its metadata """
+        # Use font with index idx if this is a font collection file
+        found = self.find_table([ b'head' ], idx)
+        if not found:
+            raise Exception('No HEAD table found in font idx {}'.format(idx))
+
+
+    def goto(self, where):
+        """ Go to a named location in the file or to the specified index """
+        if type(where) is str:
+            positions = {'checksumAdjustment': 2+2+4,
+                         'flags': 2+2+4+4+4,
+                         'lowestRecPPEM': 2+2+4+4+4+2+2+8+8+2+2+2+2+2,
+                }
+            where = self.tab_offset + positions[where]
+        self.f.seek(where)
+
+
+    def calc_full_checksum(self, check = False):
+        """ Calculate the whole file's checksum """
+        self.f.seek(0, 2)
+        self.end = self.f.tell()
+        full_check = self.calc_checksum(0, self.end, (-self.checksum_adj) & 0xFFFFFFFF)
+        if check and (0xB1B0AFBA - full_check) & 0xFFFFFFFF != self.checksum_adj:
+            sys.exit("Checksum of whole font is bad")
+        return full_check
+
+    def calc_table_checksum(self, check = False):
+        tab_check_new = self.calc_checksum(self.tab_offset, self.tab_offset + self.tab_length - 1, (-self.checksum_adj) & 0xFFFFFFFF)
+        if check and tab_check_new != self.tab_check:
+            sys.exit("Checksum of 'head' in font is bad")
+        return tab_check_new
+
+    def reset_table_checksum(self):
+        new_check = self.calc_table_checksum()
+        self.putlong(new_check, self.tab_check_offset)
+
+    def reset_full_checksum(self):
+        new_adj = (0xB1B0AFBA - self.calc_full_checksum()) & 0xFFFFFFFF
+        self.putlong(new_adj, 'checksumAdjustment')
+
+    def close(self):
+        self.f.close()
+
+
+    def __init__(self, filename):
+        self.modified = False
+        self.f = open(filename, 'r+b')
+
+        self.find_head_table(0)
+
+        self.flags = self.getshort('flags')
+        self.lowppem = self.getshort('lowestRecPPEM')
+        self.checksum_adj = self.getlong('checksumAdjustment')

--- a/rename-font
+++ b/rename-font
@@ -7,6 +7,7 @@ from argparse import ArgumentParser
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(sys.argv[0])) + '/bin/scripts/name_parser/')
 from FontnameParser import FontnameParser
+from TableHEADWriter import TableHEADWriter
 
 # Setup and parse the comand-line arguments
 parser = ArgumentParser()
@@ -18,6 +19,8 @@ parser.add_argument("--version", help="text to add to the existing version")
 args = parser.parse_args()
 
 SIL_TABLE = [('cascadia ?(code|mono)( ?pl)?', args.name), ]
+
+print("\nRenaming process\n    {}\n as {}\n -> {}".format(args.input, args.orig, args.output))
 
 fname = os.path.splitext(os.path.basename(args.orig))[0]
 n = FontnameParser(fname)
@@ -51,3 +54,19 @@ if n.ps_fontname().lower().find("mono"):
 # Save
 delugia.generate(args.output)
 print("Generated '{}' from {} version {}".format(args.output, n.fullname(), args.version))
+
+# Fix fontforge destroying the font flags
+source_font = TableHEADWriter(args.orig)
+dest_font = TableHEADWriter(args.output)
+source_font.find_head_table(0)
+dest_font.find_head_table(0)
+
+print("Changing flags from 0x{:X} to 0x{:X}".format(dest_font.flags, source_font.flags))
+dest_font.putshort(source_font.flags, 'flags') # clear 'ppem_to_int' etc
+print("Changing lowestRecPPEM from {} to {}".format(dest_font.lowppem, source_font.lowppem))
+dest_font.putshort(source_font.lowppem, 'lowestRecPPEM')
+
+dest_font.reset_table_checksum()
+dest_font.reset_full_checksum()
+source_font.close()
+dest_font.close()


### PR DESCRIPTION
**[why]**
The patched font looks different than the original Cascadia Cove font. Character height seems to differ a bit, esp at smaller sizes.

**[how]**
With Fontforge it is not possible to control some aspects of the generated font. There is no access to the ascpects from within fontforge, and they are also not preserved but rather overwritten with some default values. But these affect the font rendering engines.

Namely this are the flags and the lowest-recommended-ppem of the HEAD table in the font.

The Nerd Fonts font-patcher addresses this shortcoming by manipulating the HEAD table after the patching process directly.

But here we call (after running the font-patcher) fontforge again to rename the font. In that process the details in the HEAD table are again overwritten with stupid default values.

So we take the HEAD table manipulation code from font-patcher and call it again after the renaming.

Differently from Nerd Fonts we copy the font flags exactly and do not only clear the integer-ppem bit.

Fixes: #78