### PR TITLE
docs: update font face stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,16 @@ Compared with other patched versions of Cascadia you will find
 ### How to use
 You can download the patched fonts from the [Releases page](https://github.com/adam7/delugia-code/releases) of this
 repo and install them as you would any other font. Once installed the font can be referenced as `Delugia *`.
-So if, for example, you want to use it in Windows Terminal you should add this line to your profiles.json
+So if, for example, you want to use it in Windows Terminal you should add the lines
 
-`"fontFace" : "Delugia Complete",`
+```
+                "font":
+                {
+                    "face": "Delugia"
+                }
+```
+
+to the corresponding profiles in your settings.json.
 
 ### Installation with [Chocolatey](https://chocolatey.org/install)
 You can install your preferred version, or versions, of Delugia using the standard Chocolatey incantations.


### PR DESCRIPTION
at least in Windows Terminal v1.16 `fontFace` is marked as deprecated and the proposed change is suggested. In addition, using "Delugia Complete" returns a "font not found" error. Instead only using "Delugia" works (for the Delugia Complete font pack).

Thus, it remains to check how the correct names for the other font packs are and then to decide, if/how

https://github.com/adam7/delugia-code/blob/f1b9e2d3ebac356cb6bbaeab992d18160bb14066/README.md?plain=1#L56

needs to be adjusted (as well).