### PR TITLE
Adapt to Nerd Fonts 3.2.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,7 +163,7 @@ jobs:
         zip delugia-book.zip delugia-book/*
     - name: Check for preexisting glyphs
       run: |
-        grep 'Found existing' process*.log | grep  -vE ' Powerline(Extra)?Symbols>'
+        grep 'Skipping...' process*.log | grep  -vE ' Powerline(Extra)?Symbols>'
     - uses: actions/upload-artifact@v4
       with:
         name: Delugia Powerline

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       run: |
         echo "CASCADIATAG=${{ fromJson(steps.get_latest_release.outputs.data).tag_name }}" >> $GITHUB_ENV
     - name: Check if tag exists
-      uses: mukunku/tag-exists-action@v1.2.0
+      uses: mukunku/tag-exists-action@v1.6.0
       id: check_tag
       with:
         tag: ${{ env.CASCADIATAG }}
@@ -50,7 +50,7 @@ jobs:
       CASCADIATAG_ISNOTNEW: ${{ needs.check-for-new-cascadia.outputs.tag_exists }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Decide on version
@@ -65,7 +65,7 @@ jobs:
         fi
         echo "OURVERSION=${OURVERSION}" >> $GITHUB_ENV
     - name: Download latest version of Cascadia
-      uses: robinraju/release-downloader@v1.7
+      uses: robinraju/release-downloader@v1.10
       with:
         repository: "microsoft/cascadia-code"
         tag: ${{ needs.check-for-new-cascadia.outputs.tag_name }}
@@ -91,7 +91,7 @@ jobs:
         fontforge --version
 
     - name: Get Font Patcher
-      uses: robinraju/release-downloader@v1.5
+      uses: robinraju/release-downloader@v1.10
       with:
         repository: "ryanoasis/nerd-fonts"
         latest: true
@@ -164,23 +164,23 @@ jobs:
     - name: Check for preexisting glyphs
       run: |
         grep 'Found existing' process*.log | grep  -vE ' Powerline(Extra)?Symbols>'
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Delugia Powerline
         path: "delugia-powerline"
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Delugia Mono Powerline
         path: "delugia-mono-powerline"
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Delugia Complete
         path: "delugia-complete"
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Delugia Mono Complete
         path: "delugia-mono-complete"
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Delugia Book
         path: "delugia-book"
@@ -188,7 +188,7 @@ jobs:
     # Release part
     - name: Create tag
       if: ${{ github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/') && needs.check-for-new-cascadia.outputs.tag_exists != 'true' }}
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         github-token: ${{ github.token }}
         script: |
@@ -214,7 +214,7 @@ jobs:
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       uses: battila7/get-version-action@v2
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       if: ${{ github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/') || needs.check-for-new-cascadia.outputs.tag_exists != 'true') }}
       with:
         tag_name: ${{ startsWith(github.ref, 'refs/tags/') && steps.get_tag_name.outputs.version || needs.check-for-new-cascadia.outputs.tag_name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
     - name: Install configparser
       run: pip3 install configparser
     - name: Extract additional powerline glyphs
-      run: fontforge -lang=ff -script "`pwd`/extract-extra-glyphs" "`pwd`" `pwd`/src/**/octicons.ttf
+      run: fontforge -lang=ff -script "`pwd`/extract-extra-glyphs" "`pwd`" `pwd`/src/glyphs/octicons/octicons.ttf
     - name: Build Powerline
       run: |
         ./do_generate 01 --powerline --mono CascadiaCodePL-Regular.ttf            DelugiaPL.ttf              "Delugia PL"

--- a/do_generate
+++ b/do_generate
@@ -22,7 +22,7 @@ fi
 PWD=$( pwd )
 
 rm -f C*.ttf
-fontforge -script "${PWD}/font-patcher" --careful "${3}" --custom SomeExtraSymbols.sfd --no-progressbars "${PWD}/ttf/static/${4}" "${2}" --outputdir "${PWD}" | tee "process${1}.log"
+fontforge -script "${PWD}/font-patcher" --debug 2 --careful "${3}" --custom SomeExtraSymbols.sfd --no-progressbars "${PWD}/ttf/static/${4}" "${2}" --outputdir "${PWD}" | tee "process${1}.log"
 
 if [ -z "${OURVERSION}" ]; then
     # Github CI sets this variable, but this can be useful for manual calls:

--- a/rename-font
+++ b/rename-font
@@ -3,6 +3,7 @@
 
 import os.path
 import fontforge
+import sys, logging
 from argparse import ArgumentParser
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(sys.argv[0])) + '/bin/scripts/name_parser/')
@@ -23,7 +24,8 @@ SIL_TABLE = [('cascadia ?(code|mono)( ?pl)?', args.name), ]
 print("\nRenaming process\n    {}\n as {}\n -> {}".format(args.input, args.orig, args.output))
 
 fname = os.path.splitext(os.path.basename(args.orig))[0]
-n = FontnameParser(fname)
+logger = logging.getLogger()
+n = FontnameParser(fname, logger)
 n.add_name_substitution_table(SIL_TABLE)
 n.set_keep_regular_in_family(False)
 if not n.parse_ok:
@@ -36,7 +38,7 @@ delugia=fontforge.open(args.input)
 n.rename_font(delugia)
 
 # Other information
-delugia.appendSFNTName("English (US)", "UniqueID", "{};{}".format(args.version, n.ps_fontname()))
+delugia.appendSFNTName("English (US)", "UniqueID", "{};{}".format(args.version, n.psname()))
 delugia.appendSFNTName("English (US)", "Trademark", "")
 
 # Mix our version information in
@@ -44,7 +46,7 @@ delugia.sfntRevision = None # Auto-set (refreshed) by fontforge
 delugia.appendSFNTName("English (US)", "Version", args.version)
 delugia.version = args.version
 
-if n.ps_fontname().lower().find("mono"):
+if n.psname().lower().find("mono"):
     # For MS-Windows console apps
     panose = list(delugia.os2_panose)
     if panose[0] < 3: # https://forum.high-logic.com/postedfiles/Panose.pdf


### PR DESCRIPTION
[why]
Some internals of the font-patcher changed since 2.3.3, that we use directly.

[note]
If we run a new release we get the current CascadiaCode with Nerd Fonts v3.x.x codepoints.
The codepoints did change for some icons.
On the other hand Nerd Fonts v3.0.0 has been already a while, so most people and other software should have changed the relevant codepoints in the meantime. To get all the new features of Nerd Fonts we probably want to follow that codepoint change.

See also
* https://github.com/ryanoasis/nerd-fonts/issues/1190